### PR TITLE
Change the build system to `hatchling`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ dev = [
 ]
 
 [build-system]
-requires = ["setuptools >= 77.0.3"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project.scripts]
 east-asian-spacing = 'east_asian_spacing.__main__:main'


### PR DESCRIPTION
This is a speculative fix for the dependabot errors, reporting `Expected lockfile to change!`.

The `hatchling` is a recommended [uv build backend].

[uv build backend]: https://docs.astral.sh/uv/concepts/build-backend/
