### PR TITLE
refactor!: replace GlyphDataList with GlyphDataSet

### DIFF
--- a/src/east_asian_spacing/__init__.py
+++ b/src/east_asian_spacing/__init__.py
@@ -2,7 +2,7 @@ from east_asian_spacing.builder import Builder
 from east_asian_spacing.config import CollectionConfig, Config
 from east_asian_spacing.dump import Dump
 from east_asian_spacing.font import Font
-from east_asian_spacing.shaper import GlyphData, GlyphDataList, InkPart, Shaper, ShapeResult
+from east_asian_spacing.shaper import GlyphData, GlyphDataSet, InkPart, Shaper, ShapeResult
 from east_asian_spacing.spacing import EastAsianSpacing, GlyphSets
 from east_asian_spacing.tester import EastAsianSpacingTester
 from east_asian_spacing.utils import calc_output_path, init_logging
@@ -19,7 +19,7 @@ __all__ = [
     'Dump',
     'Font',
     'GlyphData',
-    'GlyphDataList',
+    'GlyphDataSet',
     'InkPart',
     'Shaper',
     'ShapeResult',

--- a/src/east_asian_spacing/shaper.py
+++ b/src/east_asian_spacing/shaper.py
@@ -86,26 +86,19 @@ class GlyphData(object):
         self.cluster_index = cluster_index
         self.advance = advance
         self.offset = offset
-        self.text = None  # type: Optional[str]
         self.bounds = None  # type: Optional[Tuple[int]]
         self.ink_part = None  # type: Optional[InkPart]
 
-    def __eq__(self, other: 'GlyphData'):
-        return (self.glyph_id == other.glyph_id
-                and self.cluster_index == other.cluster_index
-                and self.advance == other.advance
-                and self.offset == other.offset and self.text == other.text
-                and self.bounds == other.bounds
-                and self.ink_part == other.ink_part)
+    def __eq__(self, other: GlyphData):
+        # Note that two `GlyphData` are equal as long as the glyph ids are equal.
+        # We assume that for a given glyph_id, metrics like advance/offset are consistent.
+        return self.glyph_id == other.glyph_id
 
     def __hash__(self):
-        return hash((self.glyph_id, self.cluster_index, self.advance,
-                     self.offset, self.text, self.bounds, self.ink_part))
+        return hash(self.glyph_id)
 
     def __str__(self):
         values = []
-        if self.text:
-            values.append(f't:"{self.text}"')
         if self.cluster_index is not None:
             values.append(f'c:{self.cluster_index}')
         values.append(f'g:{self.glyph_id}')
@@ -139,108 +132,112 @@ class GlyphData(object):
         return self.ink_part
 
 
-class GlyphDataList(object):
-    """Represents a list of `GlyphData`.
+class GlyphDataSet(object):
+    """Represents a set of `GlyphData`.
 
-    This class can keep multiple different `GlyphData` for a glyph id by using
-    a `List` as its internal storage. But the interface is similar to `dict` or
-    `set`, to ease `set`-like operations such as unions or subtractions.
+    The interface is similar to `dict` or `set`,
+    to ease `set`-like operations such as unions or subtractions.
     """
 
-    def __init__(self, glyphs: Optional[Iterable[GlyphData]] = None):
-        self._glyphs = []  # type: List[GlyphData]
-        if glyphs is not None:
-            self |= glyphs
+    def __init__(self,
+                 glyphs: Optional[Union[GlyphDataSet, ShapeResult,
+                                        Iterable[GlyphData]]] = None):
+        self._texts_by_glyph = {}  # type: Dict[GlyphData, Set[str]]
+        self |= glyphs
 
     def __eq__(self, other):
-        if type(other) is GlyphDataList:
-            return self._glyphs == other._glyphs
-        return self._glyphs == other
+        return self._texts_by_glyph == other._texts_by_glyph
 
     def __bool__(self):
-        return len(self._glyphs) > 0
+        return len(self._texts_by_glyph) > 0
 
     def __len__(self):
-        return len(self._glyphs)
+        return len(self._texts_by_glyph)
 
     def __iter__(self):
-        return iter(self._glyphs)
+        return iter(self._texts_by_glyph)
 
     def __contains__(self, glyph: Union[GlyphData, int]):
         if type(glyph) is GlyphData:
-            return glyph in self._glyphs
+            return glyph in self._texts_by_glyph
         if type(glyph) is int:
             return glyph in self.glyph_ids
         assert False
 
     def __or__(self, other: Optional[Iterable[GlyphData]]):
-        result = GlyphDataList(self)
+        result = GlyphDataSet(self)
         result |= other
         return result
 
     def __str__(self):
         return str(list(self.glyph_ids))
 
+    def get_texts(self, glyph: GlyphData) -> Set[str]:
+        return self._texts_by_glyph[glyph]
+
     @property
     def glyph_ids(self):
-        return (g.glyph_id for g in self._glyphs)
+        return (g.glyph_id for g in self._texts_by_glyph)
 
     @property
     def glyph_id_set(self) -> Set[int]:
         return set(self.glyph_ids)
 
-    def isdisjoint(self, other: 'GlyphDataList'):
-        return self.glyph_id_set.isdisjoint(other.glyph_id_set)
+    def isdisjoint(self, other: GlyphDataSet):
+        return self._texts_by_glyph.keys().isdisjoint(
+            other._texts_by_glyph.keys())
 
-    def group_by_glyph_id(self) -> Iterator[Tuple[int, 'GlyphDataList']]:
+    def glyph_id_and_glyph(self) -> Iterator[Tuple[int, GlyphData]]:
+        return ((glyph.glyph_id, glyph) for glyph in self._texts_by_glyph)
 
-        def key_func(g):
-            return g.glyph_id
-
-        glyphs = sorted(self._glyphs, key=key_func)
-        glyphs = _uniq(glyphs)
-        result = itertools.groupby(glyphs, key=key_func)
-        result = map(lambda t: (t[0], GlyphDataList(t[1])), result)
-        return result
-
-    def add(self, glyph: GlyphData):
-        self._glyphs.append(glyph)
+    def add(self, glyph: GlyphData, texts=None):
+        self._texts_by_glyph.setdefault(glyph, set()).update(
+            set(texts) if texts else set()
+        )
 
     def clear(self):
-        self._glyphs.clear()
+        self._texts_by_glyph.clear()
 
-    def __isub__(self, other: 'GlyphDataList'):
-        assert type(other) is GlyphDataList
-        other_glyph_ids = other.glyph_id_set
-        self._glyphs = list(g for g in self._glyphs
-                            if g.glyph_id not in other_glyph_ids)
+    def __isub__(self, other: GlyphDataSet):
+        assert type(other) is GlyphDataSet
+        self._texts_by_glyph = {
+            glyph: self._texts_by_glyph[glyph]
+            for glyph in self._texts_by_glyph.keys() -
+            other._texts_by_glyph.keys()
+        }
         return self
 
-    def __ior__(self, other: Optional[Iterable[GlyphData]]):
+    def __ior__(self, other):
         if other is None:
             return self
-        self._glyphs.extend(other)
+
+        if isinstance(other, (GlyphDataSet, ShapeResult)):
+            for glyph in other:
+                self._texts_by_glyph.setdefault(glyph, set()).update(
+                    other.get_texts(glyph))
+            return self
+
+        for glyph in other:
+            self._texts_by_glyph.setdefault(glyph, set())
         return self
 
     def ifilter(self,
                 predicate: Callable[[GlyphData], bool],
-                non_match: 'GlyphDataList' = None) -> None:
-        match = []
-        for glyph in self._glyphs:
-            if predicate(glyph):
-                match.append(glyph)
-            elif non_match:
-                non_match.add(glyph)
-        self._glyphs = match
+                non_match: Optional[GlyphDataSet] = None) -> None:
+        for glyph in list(self._texts_by_glyph.keys()):
+            if not predicate(glyph):
+                texts = self._texts_by_glyph.pop(glyph)
+                if non_match:
+                    non_match.add(glyph, texts)
 
     def ifilter_advance(self,
                         advance: int,
-                        non_match: 'GlyphDataList' = None) -> None:
+                        non_match: Optional[GlyphDataSet] = None) -> None:
         self.ifilter(lambda g: g.advance == advance, non_match)
 
     def ifilter_ink_part(self,
                          ink_part: InkPart,
-                         non_match: 'GlyphDataList' = None) -> None:
+                         non_match: Optional[GlyphDataSet] = None) -> None:
         for g in self:
             assert g.ink_part is not None
         self.ifilter(lambda g: g.ink_part == ink_part, non_match)
@@ -249,7 +246,8 @@ class GlyphDataList(object):
 class ShapeResult(object):
 
     def __init__(self, glyphs: Iterable[GlyphData] = ()):
-        self._glyphs = tuple(glyphs)
+        self._glyphs = list(glyphs)
+        self._texts_by_glyph = {}  # type: Dict[GlyphData, Set[str]]
 
     def __eq__(self, other):
         return self._glyphs == other._glyphs
@@ -258,13 +256,16 @@ class ShapeResult(object):
         return len(self._glyphs)
 
     def __iter__(self) -> Iterator[GlyphData]:
-        return self._glyphs.__iter__()
+        return iter(self._glyphs)
 
     def __getitem__(self, item):
         return self._glyphs[item]
 
+    def get_texts(self, glyph: GlyphData) -> Set[str]:
+        return self._texts_by_glyph.get(glyph, set())
+
     def ifilter(self, predicate):
-        self._glyphs = tuple(filter(predicate, self._glyphs))
+        self._glyphs = [g for g in self._glyphs if predicate(g)]
 
     def ifilter_advance(self, advance: int) -> None:
         self.ifilter(lambda g: g.advance == advance)
@@ -284,24 +285,27 @@ class ShapeResult(object):
         return (g.glyph_id for g in self._glyphs)
 
     def set_text(self, text):
-        if len(self._glyphs) == 0:
+        if not self._glyphs:
             return
-        last = self._glyphs[0]
-        for glyph in self._glyphs[1:]:
-            last.text = text[last.cluster_index:glyph.cluster_index]
+        glyphs = iter(self._glyphs)
+        last = next(glyphs)
+        for glyph in glyphs:
+            t = text[last.cluster_index:glyph.cluster_index]
+            self._texts_by_glyph.setdefault(last, set()).add(t)
             last = glyph
-        last.text = text[last.cluster_index:]
+        t = text[last.cluster_index:]
+        self._texts_by_glyph.setdefault(last, set()).add(t)
 
     def clear_cluster_indexes(self):
         for g in self:
             g.clear_cluster_index()
 
     def compute_ink_parts(self, font):
-        for g in self._glyphs:
+        for g in self:
             g.compute_ink_part(font)
 
     def __str__(self):
-        return f'[{",".join(str(g) for g in self._glyphs)}]'
+        return f'[{",".join(f"{g}({self._texts_by_glyph.get(g)})" for g in self._glyphs)}]'
 
 
 class ShaperBase(object):

--- a/src/east_asian_spacing/spacing.py
+++ b/src/east_asian_spacing/spacing.py
@@ -21,7 +21,7 @@ from fontTools.ttLib.tables import otTables
 
 from east_asian_spacing.config import Config
 from east_asian_spacing.font import Font
-from east_asian_spacing.shaper import GlyphData, GlyphDataList
+from east_asian_spacing.shaper import GlyphData, GlyphDataSet
 from east_asian_spacing.shaper import InkPart
 from east_asian_spacing.shaper import Shaper
 from east_asian_spacing.utils import init_logging
@@ -37,19 +37,19 @@ def _is_shaper_log_enabled():
 class GlyphSets(object):
 
     def __init__(self,
-                 left: Optional[GlyphDataList] = None,
-                 right: Optional[GlyphDataList] = None,
-                 middle: Optional[GlyphDataList] = None,
-                 space: Optional[GlyphDataList] = None):
-        self.left = left if left is not None else GlyphDataList()
-        self.right = right if right is not None else GlyphDataList()
-        self.middle = middle if middle is not None else GlyphDataList()
-        self.space = space if space is not None else GlyphDataList()
+                 left: Optional[GlyphDataSet] = None,
+                 right: Optional[GlyphDataSet] = None,
+                 middle: Optional[GlyphDataSet] = None,
+                 space: Optional[GlyphDataSet] = None):
+        self.left = left if left is not None else GlyphDataSet()
+        self.right = right if right is not None else GlyphDataSet()
+        self.middle = middle if middle is not None else GlyphDataSet()
+        self.space = space if space is not None else GlyphDataSet()
 
         # Not-applicable left and right. They are not kerned, but they can
         # appear in the context.
-        self.na_left = GlyphDataList()
-        self.na_right = GlyphDataList()
+        self.na_left = GlyphDataSet()
+        self.na_right = GlyphDataSet()
 
         self._add_glyphs_count = 0
         # For checking purposes. Because this class keeps glyph IDs, using the
@@ -57,7 +57,7 @@ class GlyphSets(object):
         # except they share the same glyph set.
         self._root_font = None
         # For debug/font analysis purpose, keeps all `GlyphData`.
-        self._all_glyphs = GlyphDataList()
+        self._all_glyphs = GlyphDataSet()
 
     def assert_font(self, font):
         if self._root_font:
@@ -66,18 +66,18 @@ class GlyphSets(object):
             self._root_font = font.root_or_self
 
     @property
-    def _glyph_data_lists(self):
+    def _glyph_data_sets(self):
         return (self.left, self.right, self.middle, self.space)
 
     @property
-    def _name_and_glyph_data_lists(self):
+    def _name_and_glyph_data_sets(self):
         return (('left', self.left), ('right', self.right),
                 ('middle', self.middle), ('space', self.space))
 
     @property
     def glyph_id_set(self) -> Set[int]:
         glyph_ids = set()
-        for glyph_data_set in self._glyph_data_lists:
+        for glyph_data_set in self._glyph_data_sets:
             glyph_ids |= glyph_data_set.glyph_id_set
         return glyph_ids
 
@@ -92,60 +92,59 @@ class GlyphSets(object):
         assert self.right.isdisjoint(self.na_right)
 
     def _to_str(self, glyph_ids=False):
-        name_and_glyph_data_lists = self._name_and_glyph_data_lists
+        name_and_glyph_data_sets = self._name_and_glyph_data_sets
         # Filter out empty glyph sets.
-        name_and_glyph_data_lists = filter(
+        name_and_glyph_data_sets = filter(
             lambda name_and_glyph: name_and_glyph[1],
-            name_and_glyph_data_lists)
+            name_and_glyph_data_sets)
         if glyph_ids:
             strs = (f'{name}={sorted(glyphs.glyph_ids)}'
-                    for name, glyphs in name_and_glyph_data_lists)
+                    for name, glyphs in name_and_glyph_data_sets)
         else:
             strs = (f'{len(glyphs)}{name[0].upper()}'
-                    for name, glyphs in name_and_glyph_data_lists)
+                    for name, glyphs in name_and_glyph_data_sets)
         return ', '.join(strs)
 
     def __str__(self):
         return self._to_str()
 
     def save_glyphs(self, output, prefix='', separator='\n', comment=0):
-        glyphs_by_glyph_id = (dict(self._all_glyphs.group_by_glyph_id())
-                              if comment else None)
 
-        def str_from_glyph_data(glyph_data: GlyphData):
-            if comment <= 1:
-                return ' '.join(f'U+{ord(c):04X} {c}' for c in glyph_data.text)
-            return str(glyph_data)
+        def comment_from_glyph(glyph: GlyphData, texts: Set[str], prefix=' # '):
+            if comment == 0:
+                return ''
 
-        def str_from_glyph_id(glyph_id):
-            if glyphs_by_glyph_id:
-                glyph_data_list = glyphs_by_glyph_id.get(glyph_id)
-                if glyph_data_list:
-                    glyph_data_list = (str_from_glyph_data(g)
-                                       for g in glyph_data_list)
-                    glyph_data_list = ', '.join(glyph_data_list)
-                    return f'{glyph_id} # {glyph_data_list}'
-            return str(glyph_id)
+            def format_text(t):
+                if len(t) == 1:
+                    return f'U+{ord(t):04X} {t}'
+                elif len(t) == 0:
+                    return 'empty'
+                else:
+                    return f'[{" ".join(f"U+{ord(c):04X}" for c in t)}] {t}'
 
-        for name, glyph_data_list in self._name_and_glyph_data_lists:
+            if comment == 1:
+                comment_str = ', '.join(format_text(t) for t in sorted(texts))
+            else:
+                comment_str = ', '.join(f'{glyph} {format_text(t)}' for t in sorted(texts))
+            return prefix + comment_str if comment_str else ''
+
+        for name, glyph_data_set in self._name_and_glyph_data_sets:
             output.write(f'# {prefix}{name}\n')
-            glyph_ids = sorted(glyph_data_list.glyph_id_set)
-            glyph_strs = (str_from_glyph_id(g) for g in glyph_ids)
+            glyph_strs = (
+                f"{g.glyph_id}{comment_from_glyph(g, glyph_data_set.get_texts(g))}"
+                for g in sorted(glyph_data_set, key=lambda g: g.glyph_id))
             output.write(separator.join(glyph_strs))
             output.write('\n')
 
-        if glyphs_by_glyph_id:
+        if comment:
             output.write(f'# {prefix}filtered\n')
             glyph_ids = self.glyph_id_set
-            for glyph_id, glyph_data_list in sorted(
-                    glyphs_by_glyph_id.items(),
-                    key=lambda key_value: key_value[0]):
-                if glyph_id in glyph_ids:
-                    continue
-                for glyph_data in glyph_data_list:
-                    output.write(
-                        f'# {glyph_data.glyph_id} {str_from_glyph_data(glyph_data)}\n'
-                    )
+            # yapf cannot handle this correctly. See https://github.com/google/yapf/issues/1136.
+            # yapf: disable
+            filtered_strs = (f'# {g.glyph_id}{comment_from_glyph(g, self._all_glyphs.get_texts(g), prefix=' ')}' for g in sorted(self._all_glyphs, key=lambda g: g.glyph_id) if g.glyph_id not in glyph_ids)
+            # yapf: enable
+            output.write(separator.join(filtered_strs))
+            output.write('\n')
 
     def unite(self, other):
         if not other:
@@ -208,7 +207,7 @@ class GlyphSets(object):
                         unicodes,
                         language=None,
                         fullwidth=True,
-                        temporary=False) -> GlyphDataList:
+                        temporary=False) -> GlyphDataSet:
             font = self._font
             text = ''.join(chr(c) for c in unicodes)
             # Unified code points (e.g., U+2018-201D) in most fonts are Latin glyphs.
@@ -232,9 +231,9 @@ class GlyphSets(object):
             result.ifilter_missing_glyphs()
             result.clear_cluster_indexes()
             result.compute_ink_parts(font)
-            return GlyphDataList(result)
+            return GlyphDataSet(result)
 
-    async def _shape(self, font, unicodes, language=None) -> GlyphDataList:
+    async def _shape(self, font, unicodes, language=None) -> GlyphDataSet:
         shaper = GlyphSets._ShapeHelper(self, font)
         result = await shaper.shape(unicodes,
                                     language=language,
@@ -415,7 +414,7 @@ class GlyphSets(object):
             self.add_glyphs(glyph_set_trio.right.glyph_ids, "R")
 
         def add_to_trio(self, glyph_set_trio, glyphs: Iterable[GlyphData]):
-            not_cached = GlyphDataList()
+            not_cached = GlyphDataSet()
             glyph_set_by_value = {
                 None: not_cached,
                 "L": glyph_set_trio.left,
@@ -431,7 +430,7 @@ class GlyphSets(object):
         cache = GlyphSets.GlyphTypeCache.get(font, create=True)
         cache.add_trio(self)
 
-    def add_from_cache(self, font, glyphs: GlyphDataList) -> GlyphDataList:
+    def add_from_cache(self, font, glyphs: GlyphDataSet) -> GlyphDataSet:
         cache = GlyphSets.GlyphTypeCache.get(font, create=False)
         if cache is None:
             return glyphs

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -23,7 +23,7 @@ async def test_config(test_font_path, tmp_path):
 
     await builder.test()
 
-    # U+300A should fail because `cjk_opning` is limited only to U+3008.
+    # U+300A should fail because `cjk_opening` is limited only to U+3008.
     fail_config = config.clone()
     fail_config.cjk_opening = {0x300A}
     with pytest.raises(AssertionError):

--- a/tests/shaper_test.py
+++ b/tests/shaper_test.py
@@ -6,7 +6,7 @@ import pytest
 from east_asian_spacing import Font
 from east_asian_spacing import InkPart
 from east_asian_spacing import GlyphData
-from east_asian_spacing import GlyphDataList
+from east_asian_spacing import GlyphDataSet
 from east_asian_spacing import Shaper
 from east_asian_spacing import ShapeResult
 
@@ -26,7 +26,7 @@ def test_glyph_data_eq():
     result2 = ShapeResult((glyph2, glyph4))
     assert result1 == result2
 
-    glyph3.advance = 500
+    glyph3.glyph_id = 500
     assert glyph3 != glyph4
     assert result1 != result2
 
@@ -74,35 +74,35 @@ async def test_glyph_data_set(test_font_path):
     font = Font.load(test_font_path)
     shaper = Shaper(font)
     result = await shaper.shape('\uFF08\uFF09\u30FB\u56DB')
-    glyphs = GlyphDataList(result)
+    glyphs = GlyphDataSet(result)
     assert len(glyphs) == len(result)
-    assert list(glyphs.glyph_ids) == list(result.glyph_ids)
+    assert set(glyphs.glyph_ids) == set(result.glyph_ids)
 
     result2 = await shaper.shape('\u3000')
-    glyphs2 = GlyphDataList(result2)
+    glyphs2 = GlyphDataSet(result2)
 
     glyphs |= result2
     assert len(glyphs) == len(result) + len(result2)
-    assert list(glyphs.glyph_ids) == list(
+    assert set(glyphs.glyph_ids) == set(
         itertools.chain(result.glyph_ids, result2.glyph_ids))
 
     glyphs -= glyphs2
     assert len(glyphs) == len(result)
-    assert list(glyphs.glyph_ids) == list(result.glyph_ids)
+    assert set(glyphs.glyph_ids) == set(result.glyph_ids)
 
 
-def test_glyph_data_set_group_by():
+def test_glyph_data_set_glyph_id_and_glyph():
     g1 = GlyphData(1, None, 100, 0)
     g1a = GlyphData(1, None, 200, 0)
     g2 = GlyphData(2, None, 100, 0)
-    glyphs = GlyphDataList([g1, g2, g1a])
-    d = dict(glyphs.group_by_glyph_id())
-    assert d[1] == [g1, g1a]
-    assert d[2] == [g2]
+    glyphs = GlyphDataSet([g1, g2, g1a])
+    d = dict(glyphs.glyph_id_and_glyph())
+    assert d[1] == g1 or d[1] == g1a
+    assert d[2] == g2
 
-    # The list should be unique; the same `GlyphData` are removed.
+    # The set should be unique; the same `GlyphData` are removed.
     g2a = GlyphData(2, None, 100, 0)
     glyphs.add(g2a)
-    d = dict(glyphs.group_by_glyph_id())
-    assert d[1] == [g1, g1a]
-    assert d[2] == [g2]
+    d = dict(glyphs.glyph_id_and_glyph())
+    assert d[1] == g1 or d[1] == g1a
+    assert d[2] == g2 or d[2] == g2a

--- a/tests/spacing_test.py
+++ b/tests/spacing_test.py
@@ -1,6 +1,6 @@
 from east_asian_spacing import Font
 from east_asian_spacing import GlyphData
-from east_asian_spacing import GlyphDataList
+from east_asian_spacing import GlyphDataSet
 from east_asian_spacing import GlyphSets
 
 
@@ -10,8 +10,8 @@ def test_cache(test_font_path):
     g2 = GlyphData(2, 0, 0, 0)
     g3 = GlyphData(3, 0, 0, 0)
     g4 = GlyphData(4, 0, 0, 0)
-    trio = GlyphSets(GlyphDataList([g1]), GlyphDataList([g2]),
-                     GlyphDataList([g3]))
+    trio = GlyphSets(GlyphDataSet([g1]), GlyphDataSet([g2]),
+                     GlyphDataSet([g3]))
     assert trio.glyph_id_set == {1, 2, 3}
     trio.add_to_cache(font)
     trio2 = GlyphSets()


### PR DESCRIPTION
## Summary

This PR is split out from my previous larger PR and focuses only on refactoring glyph collection handling.

It replaces `GlyphDataList` with `GlyphDataSet`, making the collection semantics explicit: glyph collections are now set-like and keyed by `glyph_id`.

## Motivation

The previous `GlyphDataList` used list-based storage internally while exposing several set-like operations, such as union, subtraction, and disjoint checks.

This made the model harder to reason about because multiple `GlyphData` objects with the same `glyph_id` could coexist, while most downstream logic operates on glyph IDs.

This PR makes the intended model more explicit:

- `GlyphData` identity is based on `glyph_id`
- glyph collections are represented as sets
- text associations are stored separately from glyph metric data
- duplicate glyph IDs are deduplicated in `GlyphDataSet`

This should make future behavior changes smaller and easier to review.

## Changes

- Rename `GlyphDataList` to `GlyphDataSet`
- Update package exports from `GlyphDataList` to `GlyphDataSet`
- Change `GlyphData.__eq__()` and `GlyphData.__hash__()` to use only `glyph_id`
- Remove `GlyphData.text`
- Store glyph-to-text associations in `ShapeResult` and `GlyphDataSet`
- Add `get_texts(glyph)` for retrieving associated text values
- Replace `group_by_glyph_id()` with `glyph_id_and_glyph()`
- Update `GlyphSets` to use `GlyphDataSet`
- Update glyph saving/comment generation logic to use the new text association storage
- Update tests for the new set-based semantics
- Fix a typo in `config_test.py`: `cjk_opning` -> `cjk_opening`

## Breaking Changes

This PR changes public API and collection semantics.

- `GlyphDataList` has been renamed to `GlyphDataSet`
- `GlyphData.text` has been removed
- `GlyphData.__eq__()` and `GlyphData.__hash__()` now compare only `glyph_id`
- `GlyphDataSet` deduplicates glyphs with the same `glyph_id`
- `group_by_glyph_id()` has been removed and replaced by `glyph_id_and_glyph()`
- Code relying on list-like behavior or multiple `GlyphData` entries with the same glyph ID will need to be updated