### PR TITLE
style(UP006): Use `set` instead of `Set` for type annotation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ ignore = [
     "SIM103", # Return the condition directly
     "TRY002", # Create your own exception
     "UP004", # Class EastAsianSpacingTester` inherits from `object`
-    "UP006", # Use `set` instead of `Set` for type annotation
     "UP030", # Use implicit references for positional format fields
     "UP032", # Use f-string instead of `format` call
     "UP034", # Avoid extraneous parentheses

--- a/src/east_asian_spacing/font.py
+++ b/src/east_asian_spacing/font.py
@@ -3,7 +3,7 @@ import argparse
 import itertools
 import logging
 import pathlib
-from typing import Any, Generator, Tuple
+from typing import Any, Generator
 
 import fontTools.varLib.featureVars
 import uharfbuzz as hb
@@ -303,7 +303,7 @@ class Font(object):
             return (ttfont.getGlyphName(glyph_id) for glyph_id in glyph_ids)
         return (f'glyph{glyph_id:05}' for glyph_id in glyph_ids)
 
-    def glyph_bounds(self, glyph) -> Tuple[int]:
+    def glyph_bounds(self, glyph) -> tuple[int]:
         glyph = self.glyph_name(glyph)
         ttglyphset = self.ttglyphset
         ttglyph = ttglyphset[glyph]

--- a/src/east_asian_spacing/shaper.py
+++ b/src/east_asian_spacing/shaper.py
@@ -10,7 +10,7 @@ import os
 import pathlib
 import shlex
 from subprocess import CalledProcessError
-from typing import Callable, Iterable, Iterator, Set, Tuple
+from typing import Callable, Iterable, Iterator
 
 import uharfbuzz as hb
 
@@ -180,13 +180,13 @@ class GlyphDataList(object):
         return (g.glyph_id for g in self._glyphs)
 
     @property
-    def glyph_id_set(self) -> Set[int]:
+    def glyph_id_set(self) -> set[int]:
         return set(self.glyph_ids)
 
     def isdisjoint(self, other: 'GlyphDataList'):
         return self.glyph_id_set.isdisjoint(other.glyph_id_set)
 
-    def group_by_glyph_id(self) -> Iterator[Tuple[int, 'GlyphDataList']]:
+    def group_by_glyph_id(self) -> Iterator[tuple[int, 'GlyphDataList']]:
 
         def key_func(g):
             return g.glyph_id

--- a/src/east_asian_spacing/spacing.py
+++ b/src/east_asian_spacing/spacing.py
@@ -5,7 +5,7 @@ import itertools
 import logging
 import math
 import sys
-from typing import Iterable, List, Set, Tuple
+from typing import Iterable
 
 from fontTools.otlLib.builder import (
     ChainContextPosBuilder,
@@ -70,7 +70,7 @@ class GlyphSets(object):
                 ('middle', self.middle), ('space', self.space))
 
     @property
-    def glyph_id_set(self) -> Set[int]:
+    def glyph_id_set(self) -> set[int]:
         glyph_ids = set()
         for glyph_data_set in self._glyph_data_lists:
             glyph_ids |= glyph_data_set.glyph_id_set
@@ -472,7 +472,7 @@ class GlyphSets(object):
 
         @property
         def glyphs_value_for_right(
-                self) -> Tuple[Tuple[Tuple[str], otBase.ValueRecord]]:
+                self) -> tuple[tuple[tuple[str], otBase.ValueRecord]]:
             return ((self.right, self.right_value), )
 
         @property
@@ -510,7 +510,7 @@ class GlyphSets(object):
         return True
 
     def _add_feature(self, font: Font, table: otTables.GPOS, feature_tag: str,
-                     lookup_indices: List[int]) -> None:
+                     lookup_indices: list[int]) -> None:
         logger.debug('Adding "%s" to: "%s" %s', feature_tag, font,
                      self._to_str(glyph_ids=True))
         assert not Font._has_ottable_feature(table, feature_tag)
@@ -542,15 +542,15 @@ class GlyphSets(object):
 
         Font._sort_features_ottable(table)
 
-    def _build_halt_lookup(self, font: Font, lookups: List[otTables.Lookup],
+    def _build_halt_lookup(self, font: Font, lookups: list[otTables.Lookup],
                            pos) -> int:
         lookup = self._build_single_pos_lookup(
             font, lookups, pos.glyphs_value_for_left_right_middle)
         return lookup.lookup_index
 
     def _build_single_pos_lookup(
-        self, font: Font, lookups: List[otTables.Lookup],
-        glyphs_value_list: Tuple[Tuple[Tuple[str], otBase.ValueRecord]]
+        self, font: Font, lookups: list[otTables.Lookup],
+        glyphs_value_list: tuple[tuple[tuple[str], otBase.ValueRecord]]
     ) -> otTables.Lookup:
         self.assert_font(font)
         ttfont = font.ttfont
@@ -565,8 +565,8 @@ class GlyphSets(object):
         lookups.append(lookup)
         return lookup
 
-    def _build_chws_lookup(self, font: Font, lookups: List[otTables.Lookup],
-                           pos: 'GlyphSets.PosValues') -> List[int]:
+    def _build_chws_lookup(self, font: Font, lookups: list[otTables.Lookup],
+                           pos: 'GlyphSets.PosValues') -> list[int]:
         self.assert_font(font)
         lookup_indices = []
 

--- a/src/east_asian_spacing/tester.py
+++ b/src/east_asian_spacing/tester.py
@@ -5,7 +5,7 @@ import copy
 import itertools
 import logging
 import math
-from typing import Iterable, Set, Tuple
+from typing import Iterable
 
 from east_asian_spacing.config import Config
 from east_asian_spacing.font import Font
@@ -18,7 +18,7 @@ logger = logging.getLogger('test')
 class ShapeTest(object):
 
     @staticmethod
-    def create_list(font: Font, inputs: Iterable[Tuple[int, int]], index: int):
+    def create_list(font: Font, inputs: Iterable[tuple[int, int]], index: int):
         off_features = ['fwid']
         if font.is_vertical:
             off_features.append('vert')
@@ -29,7 +29,7 @@ class ShapeTest(object):
             for input in inputs)
         return tests
 
-    def __init__(self, font: Font, input: Tuple[int, int], index: int,
+    def __init__(self, font: Font, input: tuple[int, int], index: int,
                  features, off_features):
         self.font = font
         self.input = input
@@ -55,7 +55,7 @@ class ShapeTest(object):
     def should_have_offset(self) -> bool:
         return self.index != 0
 
-    def should_apply(self, glyph_id_sets: Tuple[Set[int]] | None, em=None):
+    def should_apply(self, glyph_id_sets: tuple[set[int]] | None, em=None):
         # If any glyphs are missing, or their advances are not em,
         # the feature should not apply.
         if em is None:
@@ -176,7 +176,7 @@ class EastAsianSpacingTester(object):
         return tests
 
     async def assert_trim(self, tests: Iterable[ShapeTest],
-                          glyph_id_sets: Tuple[Set[int]] | None):
+                          glyph_id_sets: tuple[set[int]] | None):
         font = self.font
         config = self._config
         coros = (test.shape(language=config.language) for test in tests)


### PR DESCRIPTION
"UP006" for #395.
