### PR TITLE
style: Use f-string instead of `format` call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,6 @@ ignore = [
     "SIM102", # Use a single `if` statement instead of nested `if` statements
     "SIM103", # Return the condition directly
     "TRY002", # Create your own exception
-    "UP030", # Use implicit references for positional format fields
-    "UP032", # Use f-string instead of `format` call
 ]
 
 [tool.setuptools_scm]

--- a/src/east_asian_spacing/dump.py
+++ b/src/east_asian_spacing/dump.py
@@ -147,9 +147,12 @@ class Dump:
         for entry in entries:
             sum_data += entry.size
             sum_gap += entry.gap
-        print("Total: {0:,}\nData: {1:,}\nGap: {2:,}\nTables: {3}".format(
-            sum_data + sum_gap, sum_data, sum_gap, len(entries)),
-              file=out_file)
+        print(
+            f"Total: {sum_data + sum_gap:,}\n"
+            f"Data: {sum_data:,}\n"
+            f"Gap: {sum_gap:,}\n"
+            f"Tables: {len(entries)}",
+            file=out_file)
 
     @staticmethod
     def dump_features(font, face_index, tag, out_file=sys.stdout):


### PR DESCRIPTION
Stop ignoring following rules for #395.
* UP030 Use implicit references for positional format fields
* UP032 Use f-string instead of `format` call
